### PR TITLE
Update challenge layout

### DIFF
--- a/challenge1.html
+++ b/challenge1.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body style="text-align:center; font-family: Comic Sans MS, cursive;">
-  <h1>Challenge 1: Move the Robot</h1>
-  <iframe src="https://blockly.games/maze?lang=en&level=2" style="width: 100%; height: 500px; border: none;"></iframe>
+  <h1>Challenges</h1>
+  <iframe src="https://blockly.games/maze?lang=en&level=2" style="width: 100%; height: 90vh; border: none;"></iframe>
   <br><br>
   <button onclick="markComplete()" style="padding: 10px 20px; font-size: 1.2em;">✅ I Did It!</button>
   <p id="feedback"></p>

--- a/index.html
+++ b/index.html
@@ -74,19 +74,7 @@
 
   <div class="challenges">
     <div class="card">
-      <a href="challenge1.html">🔧 Challenge 1: Move the Robot</a>
-    </div>
-    <div class="card locked">
-      🔒 Challenge 2: Light It Up
-    </div>
-    <div class="card locked">
-      🔒 Challenge 3: Loop Champ
-    </div>
-    <div class="card locked">
-      🔒 Challenge 4: Bug Finder
-    </div>
-    <div class="card locked">
-      🔒 Challenge 5: Animation Star
+      <a href="challenge1.html">Challenges</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- show only a single Challenges card on the homepage
- rename challenge page header to `Challenges`
- make the Blockly iframe fill the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68889e3b9f388331b56b3b1a4f3245c0