### PR TITLE
Add shape utilities and responsive image toggles

### DIFF
--- a/challenge1.html
+++ b/challenge1.html
@@ -11,7 +11,7 @@
 <body>
 <nav class="navbar navbar-light bg-light mb-3">
   <div class="container-fluid">
-    <a class="navbar-brand" href="index.html">Code with Ite <img src="ite_pose.jpg" alt="Ite" class="banner-img"/></a>
+    <a class="navbar-brand" href="index.html">Code with Ite <img id="nav-pose" src="ite_pose.jpg" alt="Ite" class="banner-img rounded-square" onclick="toggleNavShape()"/></a>
   </div>
 </nav>
   <div class="container-lg mt-4">
@@ -28,6 +28,10 @@
     function markComplete() {
       localStorage.setItem('challenge1', 'complete');
       document.getElementById('feedback').textContent = 'Great job, Ite! Badge unlocked: Starter Coder 🎉';
+    }
+
+    function toggleNavShape() {
+      document.getElementById('nav-pose').classList.toggle('rounded-circle');
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,14 @@
   <div class="container-lg mt-4">
   <h1>Welcome to Code with Ite 👋</h1>
   <p><strong>Built by Uncle Ayo 🧠💥</strong></p>
-  <img src="ite_pose.jpg" alt="Ite posing" class="banner-img" />
+  <div class="row align-items-center mb-3">
+    <div class="col-12 col-lg-6">
+      <img id="pose-img" src="ite_pose.jpg" alt="Ite posing" class="banner-img rounded-square" onclick="togglePoseShape()" />
+    </div>
+    <div class="col-12 col-lg-6">
+      <img id="baby-img" src="ite_baby.jpg" alt="Little Ite" class="side-img rounded-square" onclick="toggleBabyShape()" />
+    </div>
+  </div>
   <p>Choose a challenge and unlock your coding badges. Let’s gooo!</p>
 
   <div class="challenges">
@@ -25,8 +32,6 @@
       <a href="challenge1.html" class="btn btn-primary">🔧 Challenges</a>
     </div>
   </div>
-
-  <img src="ite_baby.jpg" alt="Little Ite" class="side-img" />
 
   <div class="badges">
     <h2>🏅 Your Badges</h2>
@@ -47,6 +52,14 @@
           document.getElementById(`badge${i}`).classList.add('unlocked');
         }
       }
+    }
+
+    function togglePoseShape() {
+      document.getElementById('pose-img').classList.toggle('rounded-circle');
+    }
+
+    function toggleBabyShape() {
+      document.getElementById('baby-img').classList.toggle('clip-star');
     }
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -102,3 +102,19 @@ iframe {
   border-radius: 12px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
+
+/* Image shape utilities */
+.rounded-square {
+  border-radius: 0 !important;
+}
+
+.rounded-circle {
+  border-radius: 50% !important;
+}
+
+/* Star shaped clipping for fun */
+.clip-star {
+  clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%,
+    50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary
- add reusable CSS classes `.rounded-square`, `.rounded-circle`, and `.clip-star`
- use Bootstrap grid for images on the home page
- add JS helpers to toggle shapes on the images
- allow navbar image on the first challenge page to toggle shape

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888ba3a56fc833199809278194fc390